### PR TITLE
feat: support tool use training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, we support the following fine-tuning strategies:
 We will keep extending the base models and fine-tuning strategies we support, and keep adding more features, to help our users fine-tune Cohere's models more easily, more efficiently and with higher quality.
 
 ## 1. Prerequisites
-- You need to have access to a machine with at least one GPU. The specific required number, memory and model of GPUs depend on your specific use case, e.g., the model to fine-tune, the batch size, the max sequence length in the data, etc.
+- You need to have access to a machine with at least one GPU, e.g., H100, H200, etc. The specific required number, memory and model of GPUs depend on your specific use case, e.g., the model to fine-tune, the batch size, the max sequence length in the data, etc.
 - You need to install necessary apps, e.g., Docker, Git, etc. on the GPU machine.
 
 To help you better decide the hardware resources you need, we list some feasible scenarios in the following table as a reference, where all the other hyperparameters that are not shown in the table are set as their default values (see [here](#step-4-submit-the-request-to-start-the-fine-tuning)).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY ./docker/cuda.repo /etc/yum.repos.d/cuda.repo
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gnupg2=2.2.27-3ubuntu2.1 \
-        curl=7.81.0-1ubuntu1.19 \
+        curl \
         ca-certificates=20240203~22.04.1 \
     && curl -fsSLO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \
     && dpkg -i cuda-keyring_1.0-1_all.deb \

--- a/src/cohere_finetune/chat_utils.py
+++ b/src/cohere_finetune/chat_utils.py
@@ -5,21 +5,20 @@ def is_valid_chat(chat: dict) -> bool:
     """Check whether the input is a valid chat in the valid format."""
     try:
         assert isinstance(chat, dict) and len(chat) == 1 and isinstance(chat["messages"], list)
-        n_user, n_chatbot = 0, 0
+        n_system_role_curr_turn, n_user_role_curr_turn = 0, 0
+        n_chatbot_role_total = 0
         for i, message in enumerate(chat["messages"]):
             assert isinstance(message, dict) and len(message) == 2 and isinstance(message["content"], str)
-            if i == 0:
-                if message["role"] == "User":
-                    n_user += 1
-                else:
-                    assert message["role"] == "System"
+            if message["role"] == "System":
+                n_system_role_curr_turn += 1
+            elif message["role"] == "User":
+                n_user_role_curr_turn += 1
             else:
-                if message["role"] == "User":
-                    n_user += 1
-                else:
-                    assert message["role"] == "Chatbot" and n_user > 0
-                    n_chatbot += 1
-        assert n_user > 0 and n_chatbot > 0
+                assert message["role"] == "Chatbot"
+                assert n_user_role_curr_turn > 0 or (n_system_role_curr_turn > 0 and i > 1)
+                n_system_role_curr_turn, n_user_role_curr_turn = 0, 0
+                n_chatbot_role_total += 1
+        assert n_chatbot_role_total > 0
         return True
     except (AssertionError, KeyError):
         return False

--- a/src/cohere_finetune/chat_utils.py
+++ b/src/cohere_finetune/chat_utils.py
@@ -2,7 +2,12 @@ import json
 
 
 def is_valid_chat(chat: dict) -> bool:
-    """Check whether the input is a valid chat in the valid format."""
+    """
+    Check whether the input is a valid chat in the valid format.
+
+    If the first message is a System message, it will be regarded as preamble. Except for this, a System message
+    is regarded as equivalent to a User message (they are exchangeable).
+    """
     try:
         assert isinstance(chat, dict) and len(chat) == 1 and isinstance(chat["messages"], list)
         n_system_role_curr_turn, n_user_role_curr_turn = 0, 0

--- a/tests/test_chat_utils.py
+++ b/tests/test_chat_utils.py
@@ -1,0 +1,170 @@
+from chat_utils import is_valid_chat
+
+
+def test_is_valid_chat() -> None:
+    """Test the function is_valid_chat."""
+
+    # The following chats are valid.
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "User", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "System", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "System", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "System", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "System", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+                {"role": "System", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+
+    # The following chats are invalid.
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "Assistant", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "message": ""},
+                {"role": "Chatbot", "message": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": 0},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+                {"role": "User", "content": ""},
+            ]
+        }
+    )
+    assert not is_valid_chat(
+        {
+            "messages": [
+                {"role": "System", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -6,6 +6,10 @@ from tokenizer_utils import create_and_prepare_tokenizer
 
 def test_preprocess_chat() -> None:
     """Test the function preprocess_chat."""
+    liquid_template = Liquid(CHAT_PROMPT_TEMPLATE_CMD_R_08_2024, from_file=False)
+    tokenizer = create_and_prepare_tokenizer("CohereForAI/c4ai-command-r-08-2024")
+
+    # Test case 1
     chat = [
         {"role": "User", "content": "This is user message one"},
         {"role": "Chatbot", "content": "This is chatbot message one"},
@@ -13,8 +17,6 @@ def test_preprocess_chat() -> None:
         {"role": "User", "content": "This is user message three"},
         {"role": "Chatbot", "content": "This is chatbot message two"},
     ]
-    liquid_template = Liquid(CHAT_PROMPT_TEMPLATE_CMD_R_08_2024, from_file=False)
-    tokenizer = create_and_prepare_tokenizer("CohereForAI/c4ai-command-r-08-2024")
 
     prompt_turn1 = "<|START_OF_TURN_TOKEN|><|USER_TOKEN|>This is user message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
     completion_turn1 = "This is chatbot message one"
@@ -40,3 +42,26 @@ def test_preprocess_chat() -> None:
 
     preprocessed_data = preprocess_chat(chat, liquid_template=liquid_template, max_sequence_length=41, tokenizer=tokenizer)
     assert preprocessed_data == [[prompt_turn1, completion_turn1], [prompt_turn1_and_turn2, completion_turn2]]
+
+    # Test case 2 (tool use data)
+    chat = [
+        {"role": "System", "content": "This is system message one"},
+        {"role": "User", "content": "This is user message one"},
+        {"role": "Chatbot", "content": "This is chatbot message one"},
+        {"role": "System", "content": "This is system message two"},
+        {"role": "Chatbot", "content": "This is chatbot message two"},
+        {"role": "System", "content": "This is system message three"},
+        {"role": "Chatbot", "content": "This is chatbot message three"},
+    ]
+
+    prompt_turn1 = "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|># User Preamble\nThis is system message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|USER_TOKEN|>This is user message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+    completion_turn1 = "This is chatbot message one"
+
+    prompt_turn1_and_turn2 = "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|># User Preamble\nThis is system message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|USER_TOKEN|>This is user message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>This is chatbot message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>This is system message two<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+    completion_turn2 = "This is chatbot message two"
+
+    prompt_turn1_and_turn2_and_turn3 = "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|># User Preamble\nThis is system message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|USER_TOKEN|>This is user message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>This is chatbot message one<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>This is system message two<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>This is chatbot message two<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>This is system message three<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+    completion_turn3 = "This is chatbot message three"
+
+    preprocessed_data = preprocess_chat(chat, liquid_template=liquid_template, max_sequence_length=100, tokenizer=tokenizer)
+    assert preprocessed_data == [[prompt_turn1, completion_turn1], [prompt_turn1_and_turn2, completion_turn2], [prompt_turn1_and_turn2_and_turn3, completion_turn3]]


### PR DESCRIPTION
This PR supports the fine-tuning with tool use training data, where the tool use data can be in the format of `System message, User message, Chatbot message, System message, Chatbot message, System message, Chatbot message, ...`

The original chat preprocessing codes can already handle the format of tool use data, so we only need to relax our definition for a valid chat to accommodate the format of tool use data.

Some test cases have also been added.