### PR TITLE
feat: support tool use inference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ curl --request POST http://localhost:5001/inference \
     }'
 ```
 The parameters are explained below.
-- The parameter `model_name_or_path` is required, where `<model_name_or_path>` can be any model name accepted by [CohereForCausalLM.from_pretrained](https://huggingface.co/docs/transformers/main/en/model_doc/cohere#transformers.CohereForCausalLM) or a path to the merged weights of any fine-tuned model in the format of `/opt/finetuning/<finetune_sub_dir>/<finetune_name>/output/merged_weights`.
+- The parameter `model_name_or_path` is required, where the valid values of `<model_name_or_path>` are the same as those of `base_model_name_or_path` in [Step 4](#step-4-submit-the-request-to-start-the-fine-tuning). For example, it can be a path to the merged weights of any fine-tuned model in the format of `/opt/finetuning/<finetune_sub_dir>/<finetune_name>/output/merged_weights`.
 - The parameter `message` is optional (but at least one of `message` and `chat_history` must be provided), where its value can be any string. If a non-empty string is provided, we will add it as a user message `{"role": "User", "content": "<message>"}` at the end of the input.
 - The parameter `chat_history` is optional (but at least one of `message` and `chat_history` must be provided), where `<chat_history>` is a list of messages in the format of `[{"role": "User", "content": "<user_content_1>"}, {"role": "Chatbot", "content": "<chatbot_content_1>"}, ...]`.
 - The parameter `preamble` is optional, where its value can be any string. If a non-empty string is provided, we will add it as a system message `{"role": "System", "content": "<preamble>"}` at the beginning of the input.

--- a/README.md
+++ b/README.md
@@ -212,13 +212,15 @@ curl --request POST http://localhost:5001/inference \
 ```
 The parameters are explained below.
 - The parameter `model_name_or_path` is required, where `<model_name_or_path>` can be any model name accepted by [CohereForCausalLM.from_pretrained](https://huggingface.co/docs/transformers/main/en/model_doc/cohere#transformers.CohereForCausalLM) or a path to the merged weights of any fine-tuned model in the format of `/opt/finetuning/<finetune_sub_dir>/<finetune_name>/output/merged_weights`.
-- The parameter `message` is required, where its value can be any string.
-- The parameter `chat_history` is optional, where `<chat_history>` is a list of messages in the format of `[{"role": "user", "content": "<user_content_1>"}, {"role": "assistant", "content": "<assistant_content_1>"}, ...]`.
-- The parameter `preamble` is optional, where its value can be any string.
+- The parameter `message` is optional (but at least one of `message` and `chat_history` must be provided), where its value can be any string. If a non-empty string is provided, we will add it as a user message `{"role": "User", "content": "<message>"}` at the end of the input.
+- The parameter `chat_history` is optional (but at least one of `message` and `chat_history` must be provided), where `<chat_history>` is a list of messages in the format of `[{"role": "User", "content": "<user_content_1>"}, {"role": "Chatbot", "content": "<chatbot_content_1>"}, ...]`.
+- The parameter `preamble` is optional, where its value can be any string. If a non-empty string is provided, we will add it as a system message `{"role": "System", "content": "<preamble>"}` at the beginning of the input.
 - You must explicitly set the parameter `max_new_tokens` as a large enough number; if you do not set it or set it as a small number, the model generation could be truncated and our inference service currently does not allow such an incomplete generation.
 - You can also add any other parameters accepted by the [generate](https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.GenerationMixin.generate) method, e.g., `"do_sample": "false"`, etc.
 
-A caveat is that if the inference service finds the model you want to use is different from the current model it is holding, it will spend some time loading the model you want. Therefore, please do not frequently switch models during inference; you want to finish all the inferences with one model before switching to another model.
+Here are several caveats:
+- If the inference service finds the model you want to use is different from the current model it is holding, it will spend some time loading the model you want. Therefore, please do not frequently switch models during inference; you want to finish all the inferences with one model before switching to another model.
+- If you use cURL to send the request, and `<message>`, `<chat_history>` or `<preamble>` contains the single quote `'` or double quotes `"`, then you must replace `'` with `'\''` and replace `"` with `\"` to escape them.
 
 You can also run the following command to get some information of the inference service, e.g., the current model it is holding, etc.
 ```commandline

--- a/src/cohere_finetune/chat_utils.py
+++ b/src/cohere_finetune/chat_utils.py
@@ -61,20 +61,20 @@ def dedupe_chats(chats: list[dict]) -> list[dict]:
 
 def normalize_messages(messages: list[dict]) -> None:
     """
-    Normalize a list of messages in place by doing the following.
-    - If a message uses "System", "SYSTEM", etc. as the value of "role", we change it to "system"
-    - If a message uses "User", "USER", etc. as the value of "role", we change it to "user"
-    - If a message uses "Chatbot", "CHATBOT", "Assistant", etc. as the value of "role", we change it to "assistant"
-    - If a message uses the key "message", we rename it to "content"
+    To convert a list of messages into a valid input for Liquid template, normalize the messages in place by doing the following.
+    - If a message uses "system", "SYSTEM", etc. as the value of "role", we change it to "System"
+    - If a message uses "user", "USER", etc. as the value of "role", we change it to "User"
+    - If a message uses "assistant", "ASSISTANT", "chatbot", "CHATBOT", etc. as the value of "role", we change it to "Chatbot"
+    - If a message uses the key "content", we rename it to "message"
     """
     for message in messages:
         if message["role"].lower() == "system":
-            message["role"] = "system"
+            message["role"] = "System"
         elif message["role"].lower() == "user":
-            message["role"] = "user"
-        elif message["role"].lower() in {"chatbot", "assistant"}:
-            message["role"] = "assistant"
+            message["role"] = "User"
+        elif message["role"].lower() in {"assistant", "chatbot"}:
+            message["role"] = "Chatbot"
 
-        if "message" in message:
-            message["content"] = message["message"]
-            del message["message"]
+        if "content" in message:
+            message["message"] = message["content"]
+            del message["content"]

--- a/src/cohere_finetune/cohere_finetune_service.py
+++ b/src/cohere_finetune/cohere_finetune_service.py
@@ -108,7 +108,7 @@ class CohereFinetune:
             return
 
         # Create and prepare the tokenizer
-        tokenizer = create_and_prepare_tokenizer(self.hyperparameters.base_model.get_hf_model_name_or_path())
+        tokenizer = create_and_prepare_tokenizer(self.hyperparameters.base_model_config.get_hf_model_name_or_path())
 
         # Preprocess the finetuning dataset by doing train eval split (if needed) and putting the texts in template
         try:
@@ -119,8 +119,8 @@ class CohereFinetune:
                 output_train_path=self.path_config.finetune_train_path,
                 output_eval_path=self.path_config.finetune_eval_path,
                 eval_percentage=self.hyperparameters.eval_percentage,
-                template=self.hyperparameters.base_model.get_prompt_template(),
-                max_sequence_length=self.hyperparameters.base_model.get_max_possible_max_sequence_length(),
+                template=self.hyperparameters.base_model_config.get_prompt_template(),
+                max_sequence_length=self.hyperparameters.base_model_config.get_max_possible_max_sequence_length(),
                 tokenizer=tokenizer,
             )
             logger.info("Preprocessing finished")

--- a/src/cohere_finetune/cohere_inference_service.py
+++ b/src/cohere_finetune/cohere_inference_service.py
@@ -4,7 +4,7 @@ import signal
 import sys
 import time
 import torch
-from chat_utils import is_valid_chat, normalize_messages
+from chat_utils import is_valid_inference_input_chat, normalize_messages
 from flask import Flask, jsonify, request, Response
 from liquid import Liquid
 from model_config import ModelConfig
@@ -72,7 +72,7 @@ class CohereInference:
 
             messages = ([{"role": "System", "content": preamble}] if preamble else []) + \
                 chat_history + ([{"role": "User", "content": message}] if message else [])
-            if not is_valid_chat({"messages": messages}):
+            if not is_valid_inference_input_chat({"messages": messages}):
                 return jsonify({"message": "Invalid input format"})
 
             normalize_messages(messages)

--- a/src/cohere_finetune/cohere_inference_service.py
+++ b/src/cohere_finetune/cohere_inference_service.py
@@ -6,6 +6,8 @@ import time
 import torch
 from chat_utils import is_valid_chat, normalize_messages
 from flask import Flask, jsonify, request, Response
+from liquid import Liquid
+from model_config import ModelConfig
 from tokenizer_utils import create_and_prepare_tokenizer
 from transformers import CohereForCausalLM
 from transformers.modeling_utils import PreTrainedModel
@@ -39,6 +41,7 @@ class CohereInference:
         self.app = Flask(__name__)
 
         self.model_name_or_path: str | None = None
+        self.liquid_template: Liquid | None = None
         self.model: PreTrainedModel | None = None
         self.tokenizer: CohereTokenizerFast | None = None
 
@@ -52,7 +55,7 @@ class CohereInference:
         def inference() -> Response:
             """Conduct model inference on a single text."""
             model_name_or_path = request.json.pop("model_name_or_path")
-            message = request.json.pop("message")
+            message = request.json.pop("message", "")
             chat_history = request.json.pop("chat_history", [])
             preamble = request.json.pop("preamble", "")
             param = {k: json.loads(v) if v in {"false", "true"} else v for k, v in request.json.items()}
@@ -61,6 +64,7 @@ class CohereInference:
                 logger.info("Model is not loaded or needs to be changed, so loading the desired model...")
                 self._reset()  # Before loading another model, reset to release the memory used
                 self.model_name_or_path = model_name_or_path
+                self.liquid_template = Liquid(ModelConfig(model_name_or_path).get_prompt_template(), from_file=False)
                 self.model = load_model_for_inference(model_name_or_path)
                 self.tokenizer = create_and_prepare_tokenizer(model_name_or_path)
 
@@ -69,17 +73,23 @@ class CohereInference:
             messages = ([{"role": "System", "content": preamble}] if preamble else []) + \
                 chat_history + ([{"role": "User", "content": message}] if message else [])
             if not is_valid_chat({"messages": messages}):
-                return jsonify({"message": f"Invalid input format"})
+                return jsonify({"message": "Invalid input format"})
 
             normalize_messages(messages)
-            # TODO: replace the line below with Liquid Template
-            # templated_text = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            if messages[0]["role"] == "System":
+                templated_text = self.liquid_template.render(
+                    safety_mode="NONE", preamble=messages[0]["message"], messages=messages[1:]
+                )
+            else:
+                templated_text = self.liquid_template.render(
+                    safety_mode="NONE", preamble="", messages=messages
+                )
 
             """
             During training, we didn't add the special tokens like <BOS_TOKEN> to the preprocessed (templated) text,
             so we let the tokenizer add them (setting add_special_tokens=True)
 
-            During inference, we just added these special tokens by apply_chat_template,
+            During inference, we just added these special tokens by the Liquid template,
             so we don't let the tokenizer add them again (setting add_special_tokens=False)
             """
             tokenized_templated_text = self.tokenizer(
@@ -121,8 +131,9 @@ class CohereInference:
             return jsonify({"message": "Server terminated"})
 
     def _reset(self) -> None:
-        """Reset the model_name_or_path, model, and tokenizer to the original values, and release the memory."""
+        """Reset the model_name_or_path, liquid_template, model, and tokenizer to the original values, and release the memory."""
         self.model_name_or_path = None
+        self.liquid_template = None
         self.model = None
         self.tokenizer = None
         torch.cuda.empty_cache()

--- a/src/cohere_finetune/configs.py
+++ b/src/cohere_finetune/configs.py
@@ -1,8 +1,8 @@
 import json
 import os
 import torch
-from base_model import BaseModel
 from consts import FinetuneStrategy, ParallelStrategy, FINETUNE_BACKEND_KEY, PATH_PREFIX_KEY
+from model_config import ModelConfig
 from typing import Any
 
 
@@ -105,7 +105,7 @@ class Hyperparameters(BaseConfig):
     ) -> None:
         """Initialize Hyperparameters."""
         self.finetune_name = finetune_name
-        self.base_model = BaseModel(base_model_name_or_path)
+        self.base_model_config = ModelConfig(base_model_name_or_path)
         self.parallel_strategy = ParallelStrategy(parallel_strategy)
         self.finetune_strategy = FinetuneStrategy(finetune_strategy)
         self.use_4bit_quantization = json.loads(use_4bit_quantization)
@@ -119,7 +119,7 @@ class Hyperparameters(BaseConfig):
         self.lora_config = LoraConfig(**lora_config) if lora_config else LoraConfig()
         self.wandb_config = WandbConfig(**wandb_config) if wandb_config else None
 
-        self.max_sequence_length = self.base_model.get_max_possible_max_sequence_length()
+        self.max_sequence_length = self.base_model_config.get_max_possible_max_sequence_length()
 
         self._validate()
 

--- a/src/cohere_finetune/model_config.py
+++ b/src/cohere_finetune/model_config.py
@@ -33,8 +33,8 @@ def get_model_name_from_hf_config(hf_config_path: str) -> str:
 
 def get_model_config_from_model_name_and_model_path(model_name: str, model_path: str | None) -> dict:
     """
-    According to model_name and model_path, get the config of the base model,
-    which contains all information about the base model that we will use for cohere-finetune.
+    According to model_name and model_path, get the config of the model,
+    which contains all information about the model that we will use for cohere-finetune.
     """
     if model_name == "command-r":
         return {
@@ -95,7 +95,7 @@ class ModelConfig:
             model_path = None
 
         self.model_config = get_model_config_from_model_name_and_model_path(model_name, model_path)
-        logger.info(f"The base model config is as follows:\n{self.model_config}")
+        logger.info(f"The model config is as follows:\n{self.model_config}")
 
     def get_model_name(self) -> str:
         """Get the name of the model."""

--- a/src/cohere_finetune/model_config.py
+++ b/src/cohere_finetune/model_config.py
@@ -82,11 +82,11 @@ def get_model_config_from_model_name_and_model_path(model_name: str, model_path:
         raise ValueError(f"{model_name} is not a valid and supported model name")
 
 
-class BaseModel:
-    """Base model for finetuning."""
+class ModelConfig:
+    """Model configuration."""
 
     def __init__(self, model_name_or_path: str) -> None:
-        """Initialize BaseModel."""
+        """Initialize ModelConfig."""
         try:
             model_name = get_model_name_from_hf_config(os.path.join(model_name_or_path, "config.json"))
             model_path = model_name_or_path

--- a/src/cohere_finetune/preprocess.py
+++ b/src/cohere_finetune/preprocess.py
@@ -118,7 +118,7 @@ def preprocess_chat(
     """
     Preprocess a single chat.
 
-    A chat is a sequence of messages such as: Preamble, User1, Chatbot1, User2, User3, Chatbot2,
+    Here, a chat is defined as a sequence of messages such as: Preamble, User1, Chatbot1, User2, User3, Chatbot2,
     where there are two turns in this example: [User1, Chatbot1], [User2, User3, Chatbot2]
 
     If the number of tokens of Preamble + User2 + User3 + Chatbot2 > max_sequence_length,

--- a/src/cohere_finetune/preprocess.py
+++ b/src/cohere_finetune/preprocess.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import random
-from chat_utils import dedupe_chats, is_valid_chat
+from chat_utils import dedupe_chats, is_valid_training_sample_chat
 from liquid import Liquid
 from tokenizer_utils import get_n_tokens_in_rendered_prompt_completion
 from tqdm import tqdm
@@ -54,7 +54,7 @@ def preprocess(
 
 def get_valid_deduped_chats(chats: list[dict]) -> list[dict]:
     """Get all the valid and deduped chats from a given list of chats."""
-    valid_chats = [chat for chat in chats if is_valid_chat(chat)]
+    valid_chats = [chat for chat in chats if is_valid_training_sample_chat(chat)]
     logger.info(
         f"{len(valid_chats)} valid chats loaded, "
         f"while {len(chats) - len(valid_chats)} chats dropped as they are not in a valid format"
@@ -118,7 +118,7 @@ def preprocess_chat(
     """
     Preprocess a single chat.
 
-    Here, a chat is defined as a sequence of messages such as: Preamble, User1, Chatbot1, User2, User3, Chatbot2,
+    Here, for simplicity, we define a chat as a list of messages such as: Preamble, User1, Chatbot1, User2, User3, Chatbot2,
     where there are two turns in this example: [User1, Chatbot1], [User2, User3, Chatbot2]
 
     If the number of tokens of Preamble + User2 + User3 + Chatbot2 > max_sequence_length,

--- a/src/cohere_finetune/train.py
+++ b/src/cohere_finetune/train.py
@@ -54,7 +54,7 @@ def train_with_peft(path_config: CoherePeftPathConfig, hyperparameters: Hyperpar
         peft_cmd = ["python"]
 
     # Get the HuggingFace model name
-    model_name_or_path = hyperparameters.base_model.get_hf_model_name_or_path()
+    model_name_or_path = hyperparameters.base_model_config.get_hf_model_name_or_path()
 
     # Get the per_device_train_batch_size and per_device_eval_batch_size
     per_device_train_batch_size, r_train = divmod(

--- a/tests/test_chat_utils.py
+++ b/tests/test_chat_utils.py
@@ -1,11 +1,11 @@
-from chat_utils import is_valid_chat
+from chat_utils import is_valid_training_sample_chat
 
 
-def test_is_valid_chat() -> None:
-    """Test the function is_valid_chat."""
+def test_is_valid_training_sample_chat() -> None:
+    """Test the function is_valid_training_sample_chat."""
 
-    # The following chats are valid.
-    assert is_valid_chat(
+    # The following are valid chats we can use as training samples.
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},
@@ -14,7 +14,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert is_valid_chat(
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": ""},
@@ -22,21 +22,10 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert is_valid_chat(
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},
-                {"role": "User", "content": ""},
-                {"role": "Chatbot", "content": ""},
-                {"role": "User", "content": ""},
-                {"role": "User", "content": ""},
-                {"role": "Chatbot", "content": ""},
-            ]
-        }
-    )
-    assert is_valid_chat(
-        {
-            "messages": [
                 {"role": "User", "content": ""},
                 {"role": "Chatbot", "content": ""},
                 {"role": "User", "content": ""},
@@ -45,7 +34,18 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert is_valid_chat(
+    assert is_valid_training_sample_chat(
+        {
+            "messages": [
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "User", "content": ""},
+                {"role": "Chatbot", "content": ""},
+            ]
+        }
+    )
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": ""},
@@ -55,7 +55,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert is_valid_chat(
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},
@@ -68,7 +68,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert is_valid_chat(
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": ""},
@@ -81,7 +81,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert is_valid_chat(
+    assert is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},
@@ -91,8 +91,8 @@ def test_is_valid_chat() -> None:
         }
     )
 
-    # The following chats are invalid.
-    assert not is_valid_chat(
+    # The following are invalid chats we cannot use as training samples.
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": ""},
@@ -100,7 +100,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "message": ""},
@@ -108,7 +108,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": 0},
@@ -116,7 +116,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": ""},
@@ -125,34 +125,34 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "User", "content": ""},
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "Chatbot", "content": ""},
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},
@@ -160,7 +160,7 @@ def test_is_valid_chat() -> None:
             ]
         }
     )
-    assert not is_valid_chat(
+    assert not is_valid_training_sample_chat(
         {
             "messages": [
                 {"role": "System", "content": ""},


### PR DESCRIPTION
This PR supports the inference with tool use data, where the tool use data can be in the format of `System message, User message, Chatbot message, System message, Chatbot message, System message, Chatbot message, ...`

The main idea is to use Liquid template, instead of the template in the HuggingFace tokenizer, during inference. The main changes are in [cohere_inference_service.py](https://github.com/cohere-ai/cohere-finetune/blob/a1b3c2e84004e9ec29ad442f6b92d24dc1306cf1/src/cohere_finetune/cohere_inference_service.py) and all the other changes are made to accommodate the changes in this file.

This PR has been tested from end to end, and all the fine-tunings and inferences work well as before.