### PR TITLE
fix: disable NCCL NVLS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -133,6 +133,7 @@ RUN pip install --no-cache-dir \
 ENV CPATH=/root/.pyenv/versions/3.10.12/lib/python3.10/site-packages/nvidia/cusparse/include:${CPATH}
 ENV CPATH=/root/.pyenv/versions/3.10.12/lib/python3.10/site-packages/nvidia/cublas/include:${CPATH}
 ENV CPATH=/root/.pyenv/versions/3.10.12/lib/python3.10/site-packages/nvidia/cusolver/include:${CPATH}
+ENV NCCL_NVLS_ENABLE=0
 
 # Add autoawq for quantization testing
 # We ignore their requirements for nvidia-cudnn-cu12-8.9.2.26, torch-2.3.1, triton-2.3.1


### PR DESCRIPTION
This PR disables NCCL NVLS, to avoid an NCCL error raised when fine-tuning with FSDP.

Thorough tests have been conducted for this PR. After disabling NCCL NVLS, it works well with FSDP and DeepSpeed, and we don't observe any degradation in terms of fine-tuning efficiency or fine-tuning quality.